### PR TITLE
feat(IDB): use a single request.onerror function

### DIFF
--- a/dist/localforage-removeitems.es6.js
+++ b/dist/localforage-removeitems.es6.js
@@ -33,20 +33,24 @@ function removeItemsIndexedDB(keys, callback) {
             var dbInfo = localforageInstance._dbInfo;
             var transaction = dbInfo.db.transaction(dbInfo.storeName, 'readwrite');
             var store = transaction.objectStore(dbInfo.storeName);
-            var lastError;
+            var firstError;
 
             transaction.oncomplete = function () {
                 resolve();
             };
 
             transaction.onabort = transaction.onerror = function () {
-                reject(lastError || transaction.error || 'Unknown error');
+                if ( !firstError ) {
+                    reject(transaction.error || 'Unknown error');
+                }
             };
 
             function requestOnError(evt) {
                 var request = evt.target || this;
-                lastError = request.error || request.transaction.error;
-                reject(lastError);
+                if ( !firstError ) {
+                    firstError = request.error || request.transaction.error;
+                    reject(firstError);
+                }
             }
 
             for (var i = 0, len = keys.length; i < len; i++) {

--- a/dist/localforage-removeitems.js
+++ b/dist/localforage-removeitems.js
@@ -39,20 +39,24 @@
                 var dbInfo = localforageInstance._dbInfo;
                 var transaction = dbInfo.db.transaction(dbInfo.storeName, 'readwrite');
                 var store = transaction.objectStore(dbInfo.storeName);
-                var lastError;
+                var firstError;
 
                 transaction.oncomplete = function () {
                     resolve();
                 };
 
                 transaction.onabort = transaction.onerror = function () {
-                    reject(lastError || transaction.error || 'Unknown error');
+                    if ( !firstError ) {
+                        reject(transaction.error || 'Unknown error');
+                    }
                 };
 
                 function requestOnError(evt) {
                     var request = evt.target || this;
-                    lastError = request.error || request.transaction.error;
-                    reject(lastError);
+                    if ( !firstError ) {
+                        firstError = request.error || request.transaction.error;
+                        reject(firstError);
+                    }
                 }
 
                 for (var i = 0, len = keys.length; i < len; i++) {

--- a/dist/localforage-removeitems.js
+++ b/dist/localforage-removeitems.js
@@ -39,30 +39,31 @@
                 var dbInfo = localforageInstance._dbInfo;
                 var transaction = dbInfo.db.transaction(dbInfo.storeName, 'readwrite');
                 var store = transaction.objectStore(dbInfo.storeName);
-
-                var requests = [];
-                for (var i = 0, len = keys.length; i < len; i++) {
-                    var key = keys[i];
-                    if (typeof key !== 'string') {
-                        console.warn(key + ' used as a key, but it is not a string.');
-                        key = String(key);
-                    }
-                    requests.push(store.delete(key));
-                }
+                var lastError;
 
                 transaction.oncomplete = function () {
                     resolve();
                 };
 
                 transaction.onabort = transaction.onerror = function () {
-                    var err;
-                    for (var i = 0, len = requests.length; i < len && !err; i++) {
-                        var req = requests[i];
-                        err = req.error ? req.error : req.transaction.error;
-                    }
-
-                    reject(err ? err : transaction.error ? transaction.error : 'Unknown error');
+                    reject(lastError || transaction.error || 'Unknown error');
                 };
+
+                function requestOnError(evt) {
+                    var request = evt.target || this;
+                    lastError = request.error || request.transaction.error;
+                    reject(lastError);
+                }
+
+                for (var i = 0, len = keys.length; i < len; i++) {
+                    var key = keys[i];
+                    if (typeof key !== 'string') {
+                        console.warn(key + ' used as a key, but it is not a string.');
+                        key = String(key);
+                    }
+                    var request = store.delete(key);
+                    request.onerror = requestOnError;
+                }
             });
         });
         executeCallback(promise, callback);

--- a/lib/removeitems-indexeddb.js
+++ b/lib/removeitems-indexeddb.js
@@ -2,36 +2,38 @@ import { executeCallback } from './utils';
 
 export function removeItemsIndexedDB(keys, callback) {
     var localforageInstance = this;
-    var promise = localforageInstance.ready().then(function() {
-        return new Promise(function(resolve, reject) {
+    var promise = localforageInstance.ready().then(function () {
+        return new Promise(function (resolve, reject) {
             var dbInfo = localforageInstance._dbInfo;
             var transaction = dbInfo.db.transaction(dbInfo.storeName, 'readwrite');
             var store = transaction.objectStore(dbInfo.storeName);
+            var firstError;
 
-            var requests = [];
-            for (var i = 0, len = keys.length; i < len; i++) {
-                var key = keys[i];
-                if (typeof key !== 'string') {
-                    console.warn(key +
-                                        ' used as a key, but it is not a string.');
-                    key = String(key);
-                }
-                requests.push(store.delete(key));
-            }
-
-            transaction.oncomplete = function() {
+            transaction.oncomplete = function () {
                 resolve();
             };
 
-            transaction.onabort = transaction.onerror = function() {
-                var err;
-                for (var i = 0, len = requests.length; i < len && !err; i++) {
-                    var req = requests[i];
-                    err = req.error ? req.error : req.transaction.error;
-                }
-
-                reject(err ? err : transaction.error ? transaction.error : 'Unknown error');
+            transaction.onabort = transaction.onerror = function () {
+                reject(firstError || transaction.error || 'Unknown error');
             };
+
+            function requestOnError(evt) {
+                var request = evt.target || this;
+                if ( !firstError ) {
+                    firstError = request.error || request.transaction.error;
+                }
+                reject(firstError);
+            }
+
+            for (var i = 0, len = keys.length; i < len; i++) {
+                var key = keys[i];
+                if (typeof key !== 'string') {
+                    console.warn(key + ' used as a key, but it is not a string.');
+                    key = String(key);
+                }
+                var request = store.delete(key);
+                request.onerror = requestOnError;
+            }
         });
     });
     executeCallback(promise, callback);

--- a/lib/removeitems-indexeddb.js
+++ b/lib/removeitems-indexeddb.js
@@ -14,15 +14,17 @@ export function removeItemsIndexedDB(keys, callback) {
             };
 
             transaction.onabort = transaction.onerror = function () {
-                reject(firstError || transaction.error || 'Unknown error');
+                if ( !firstError ) {
+                    reject(transaction.error || 'Unknown error');
+                }
             };
 
             function requestOnError(evt) {
                 var request = evt.target || this;
                 if ( !firstError ) {
                     firstError = request.error || request.transaction.error;
+                    reject(firstError);
                 }
-                reject(firstError);
             }
 
             for (var i = 0, len = keys.length; i < len; i++) {


### PR DESCRIPTION
Imagine you have to remove 100000 items. 
With current implementation this would create 100000 functions and an array to keep the same amount of request objects. 
It is not very efficient memory-wise and we can easily avoid it.
